### PR TITLE
Do not exceed maximum allowed device type length

### DIFF
--- a/bridge.go
+++ b/bridge.go
@@ -10,7 +10,11 @@ import (
 	"runtime"
 )
 
-const maxDeviceTypeLength = 40
+// http://www.developers.meethue.com/documentation/configuration-api#71_create_user
+const (
+	maxAppNameLength = 20
+	maxDeviceNameLength = 19
+)
 
 type Bridge struct {
 	bridgeID
@@ -104,13 +108,13 @@ func (b *Bridge) pairAs(appName string) error {
 		return err
 	}
 
-	if len(appName) > 20 {
-		appName = appName[:20]
+	if len(appName) > maxAppNameLength {
+		appName = appName[:maxAppNameLength]
 	}
 
 	deviceName := fmt.Sprintf("%s-%s", runtime.GOOS, host)
-	if len(deviceName) > 19 {
-		deviceName = deviceName[:19]
+	if len(deviceName) > maxDeviceNameLength {
+		deviceName = deviceName[:maxDeviceNameLength]
 	}
 
 	msg, err := b.call(http.MethodPost, map[string]interface{}{

--- a/bridge.go
+++ b/bridge.go
@@ -104,18 +104,17 @@ func (b *Bridge) pairAs(appName string) error {
 		return err
 	}
 
-	lengthWithoutHost := len(appName) + len(runtime.GOOS) + 1 // 1 for the `-`
-	maxLengthHost := maxDeviceTypeLength - lengthWithoutHost
-	if maxLengthHost <= 0 {
-		return fmt.Errorf("appName length (%d) combined with GOOS (%d) exceed maximum allowed device type", len(appName), len(runtime.GOOS))
+	if len(appName) > 20 {
+		appName = appName[:20]
 	}
 
-	if len(host) > maxLengthHost {
-		host = host[0:maxLengthHost-1]
+	deviceName := fmt.Sprintf("%s-%s", runtime.GOOS, host)
+	if len(deviceName) > 19 {
+		deviceName = deviceName[:19]
 	}
 
 	msg, err := b.call(http.MethodPost, map[string]interface{}{
-		"devicetype": fmt.Sprintf("%s#%s-%s", appName, host, runtime.GOOS),
+		"devicetype": fmt.Sprintf("%s#%s", appName, deviceName),
 	})
 	if err != nil {
 		return err

--- a/bridge.go
+++ b/bridge.go
@@ -10,6 +10,8 @@ import (
 	"runtime"
 )
 
+const maxDeviceTypeLength = 40
+
 type Bridge struct {
 	bridgeID
 	username string
@@ -101,6 +103,17 @@ func (b *Bridge) pairAs(appName string) error {
 	if err != nil {
 		return err
 	}
+
+	lengthWithoutHost := len(appName) + len(runtime.GOOS) + 1 // 1 for the `-`
+	maxLengthHost := maxDeviceTypeLength - lengthWithoutHost
+	if maxLengthHost <= 0 {
+		return fmt.Errorf("appName length (%d) combined with GOOS (%d) exceed maximum allowed device type", len(appName), len(runtime.GOOS))
+	}
+
+	if len(host) > maxLengthHost {
+		host = host[0:maxLengthHost-1]
+	}
+
 	msg, err := b.call(http.MethodPost, map[string]interface{}{
 		"devicetype": fmt.Sprintf("%s#%s-%s", appName, host, runtime.GOOS),
 	})


### PR DESCRIPTION
You might not know, but device type length max size is 40 characters.

I figured that by try until the API didn't answered that:

```
2016/09/24 22:00:53 invalid value,  gbbr/hue#VERYLONGHOSTNAME-darwin, for parameter, devicetype
```
