### PR TITLE
Groups support added

### DIFF
--- a/bridge.go
+++ b/bridge.go
@@ -73,6 +73,7 @@ func (b Bridge) call(method string, body interface{}, tokens ...string) ([]byte,
 			return nil, err
 		}
 	}
+
 	req, err := http.NewRequest(method, b.addr(tokens...), bytes.NewReader(bd))
 	if err != nil {
 		return nil, err

--- a/groups.go
+++ b/groups.go
@@ -105,6 +105,11 @@ func (g *Group) Set(s *State) error {
 		return err
 	}
 
+	return g.Refresh()
+}
+
+// Refresh the status of the group, so we are up to date
+func (g *Group) Refresh() error {
 	r, err := g.bridge.call(http.MethodGet, nil, "groups", g.ID)
 	if err != nil {
 		return err

--- a/groups.go
+++ b/groups.go
@@ -1,0 +1,116 @@
+package hue
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+type Group struct {
+	bridge *Bridge
+
+	ID     string
+	Name   string
+	Lights []string
+	Type   string
+	Class  string
+	Action LightState
+}
+
+// Groups returns the service to interact with the groups on this bridge.
+func (b *Bridge) Groups() *GroupsService { return &GroupsService{bridge: b} }
+
+// GroupsService is the service that allows interacting with the groups API
+// of the bridge.
+type GroupsService struct{ bridge *Bridge }
+
+func (g *GroupsService) idMap() (groups map[string]*Group, err error) {
+	msg, err := g.bridge.call(http.MethodGet, nil, "groups")
+	if err != nil {
+		return nil, err
+	}
+
+	err = json.Unmarshal(msg, &groups)
+	if err != nil {
+		return groups, err
+	}
+
+	for id, group := range groups {
+		group.bridge = g.bridge
+		group.ID = id
+	}
+
+	return groups, nil
+}
+
+// List returns a slice of all groups discovered by the bridge.
+func (g GroupsService) List() ([]*Group, error) {
+	groups, err := g.idMap()
+	if err != nil {
+		return nil, err
+	}
+	list := make([]*Group, 0, len(groups))
+	for _, ll := range groups {
+		list = append(list, ll)
+	}
+	return list, nil
+}
+
+// Get returns a light by name.
+func (g *GroupsService) Get(name string) (*Group, error) {
+	list, err := g.idMap()
+	if err != nil {
+		return nil, err
+	}
+	for _, group := range list {
+		if group.Name == name {
+			return group, nil
+		}
+	}
+	return nil, ErrNotExist
+}
+
+// GetByID returns a light by id.
+func (g *GroupsService) GetByID(id string) (*Group, error) {
+	list, err := g.idMap()
+	if err != nil {
+		return nil, ErrNotExist
+	}
+	v, ok := list[id]
+	if !ok {
+		return nil, ErrNotExist
+	}
+	return v, nil
+}
+
+// On turns the group on.
+func (g *Group) On() error {
+	return g.Set(&State{On: true})
+}
+
+// Off turns the group off.
+func (g *Group) Off() error {
+	return g.Set(&State{On: false})
+}
+
+// Toggle toggles a group on/off.
+func (g *Group) Toggle() error {
+	return g.Set(&State{On: !g.Action.On})
+}
+
+// Set sets the new state of the group.
+func (g *Group) Set(s *State) error {
+
+	_, err := g.bridge.call(http.MethodPut, s, "groups", g.ID, "action")
+	if err != nil {
+		return err
+	}
+
+	r, err := g.bridge.call(http.MethodGet, nil, "groups", g.ID)
+	if err != nil {
+		return err
+	}
+	if err := json.Unmarshal(r, g); err != nil {
+		return err
+	}
+	return err
+}

--- a/groups_test.go
+++ b/groups_test.go
@@ -1,0 +1,126 @@
+package hue
+
+import (
+	"testing"
+	"net/http/httptest"
+	"net/http"
+	"encoding/json"
+	"reflect"
+)
+
+var testGroups = map[string]*Group{
+	"g1": &Group{Name: "g1name", Type: "g1type"},
+	"g2": &Group{Name: "g2name", Type: "g2type"},
+}
+
+func TestGroupsService(t *testing.T) {
+	mb := mockBridge(t)
+	defer mb.teardown()
+
+	mb.nextResponse = testGroups
+
+	t.Run("List", func(t *testing.T) {
+		list, err := mb.b.Groups().List()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if want, got := len(mb.nextResponse.(map[string]*Group)), len(list); want != got {
+			t.Fatalf("expected %d entries, got %d", want, got)
+		}
+		if list[1].ID == "" || list[0].ID == "" {
+			t.Fatalf("expected to link IDs")
+		}
+		if list[1].bridge != mb.b || list[0].bridge != mb.b {
+			t.Fatalf("expected to link lights to bridges")
+		}
+	})
+
+	t.Run("Get", func(t *testing.T) {
+		t.Run("ok", func(t *testing.T) {
+			g, err := mb.b.Groups().Get("g1name")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if g.bridge != mb.b {
+				t.Fatal("didn't link bridge")
+			}
+		})
+
+		t.Run("error", func(t *testing.T) {
+			_, err := mb.b.Groups().Get("some bogus")
+			if err != ErrNotExist {
+				t.Fatalf("expected error, got %v", err)
+			}
+		})
+	})
+
+	t.Run("GetByID", func(t *testing.T) {
+		t.Run("ok", func(t *testing.T) {
+			g, err := mb.b.Groups().GetByID("g1")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if g.bridge != mb.b {
+				t.Fatal("didn't link bridge")
+			}
+		})
+
+		t.Run("error", func(t *testing.T) {
+			_, err := mb.b.Groups().GetByID("some bogus")
+			if err != ErrNotExist {
+				t.Fatalf("expected error, got %v", err)
+			}
+		})
+	})
+}
+
+func TestGroup(t *testing.T) {
+	mb := mockBridge(t)
+	defer mb.teardown()
+	mb.nextResponse = testGroups
+
+	t.Run("Set", func(t *testing.T) {
+		mb := mockBridge(t)
+		defer mb.teardown()
+		mb.nextResponse = testGroups
+		g, err := mb.b.Groups().Get("g1name")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		want := &State{Alert: "alert123"}
+		srv := httptest.NewServer(
+			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch r.Method {
+				case http.MethodPut:
+					// on PUT request check that it's correct and return
+					// a random success string
+					s := new(State)
+					if err := json.NewDecoder(r.Body).Decode(s); err != nil {
+						t.Fatal(err)
+					}
+					if !reflect.DeepEqual(s, want) {
+						t.Fatalf("expected %v, got %v", want, s)
+					}
+					if err := json.NewEncoder(w).Encode(map[string]string{"success": "true"}); err != nil {
+						t.Fatal(err)
+					}
+				case http.MethodGet:
+					// on GET request return the new, altered state of the light
+					if err := json.NewEncoder(w).Encode(Light{
+						State: LightState{Alert: want.Alert},
+					}); err != nil {
+						t.Fatal(err)
+					}
+				default:
+					t.Fatal("unexpected request")
+				}
+			}))
+		defer srv.Close()
+
+		mb.b.bridgeID.IP = srv.URL + "/"
+		if err := g.Set(want); err != nil {
+			t.Fatal(err)
+		}
+	})
+}

--- a/lights.go
+++ b/lights.go
@@ -140,25 +140,18 @@ type Light struct {
 }
 
 // On turns the light on.
-func (l *Light) On() error { return l.Set(&State{On: true}) }
+func (l *Light) On() error {
+	return l.Set(&State{On: true})
+}
 
 // Off turns the light off.
 func (l *Light) Off() error {
-	_, err := l.bridge.call(http.MethodPut, map[string]bool{
-		"on": false,
-	}, "lights", l.ID, "state")
-	if err == nil {
-		l.State.On = false
-	}
-	return err
+	return l.Set(&State{On: false})
 }
 
 // Toggle toggles a light on/off.
 func (l *Light) Toggle() error {
-	if l.State.On {
-		return l.Off()
-	}
-	return l.On()
+	return l.Set(&State{On: !l.State.On})
 }
 
 // Rename sets the name by which this light can be addressed.
@@ -172,8 +165,7 @@ func (l *Light) Rename(name string) error {
 	return err
 }
 
-// Set sets the new state of the light. Note that Set can not turn the light off.
-// In order to do that, use the provided Off method.
+// Set sets the new state of the light.
 func (l *Light) Set(s *State) error {
 	_, err := l.bridge.call(http.MethodPut, s, "lights", l.ID, "state")
 	if err != nil {
@@ -192,7 +184,7 @@ func (l *Light) Set(s *State) error {
 // State holds a structure that is used to update a light's state.
 type State struct {
 	// On, when true, will turn a light on.
-	On bool `json:"on,omitempty"`
+	On bool `json:"on"`
 
 	// The brightness value to set the light to. Brightness is a scale from 1
 	// (the minimum the light is capable of) to 254 (the maximum).


### PR DESCRIPTION
I've added support for groups, and did some small refactoring in the lights.go code.
Note: I removed 'json:omitempty' on State.On. I also removed the custom put-request in the Off() method, because it's not necessary anymore. A `Set(&State{On: false})` will do.